### PR TITLE
Put the previously used workgroup first in the "switch to workgroup" list.

### DIFF
--- a/workgroups.el
+++ b/workgroups.el
@@ -1471,7 +1471,12 @@ Query to overwrite if a workgroup with the same name exists."
 (defun wg-read-workgroup (&optional noerror)
   "Read a workgroup with `wg-completing-read'."
   (wg-get-workgroup
-   'name (wg-completing-read "Workgroup: " (wg-names))
+   'name (wg-completing-read "Workgroup: "
+                             (let ((prev (wg-previous-workgroup t)))
+                               (if prev
+                                   (cons (wg-name prev)
+                                         (remq (wg-name prev) (wg-names)))
+                                 (wg-names))))
    noerror))
 
 (defun wg-read-buffer-name ()


### PR DESCRIPTION
wg-read-workgroup will now show the previously selected workgroup first instead of having them be sorted by name or whatever it is.

This lets you just hit "enter" to go back to the previous one instead of C-z a all the time, which suits my workflow better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tlh/workgroups.el/18)
<!-- Reviewable:end -->
